### PR TITLE
Update outdated gitlab links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ This package is meant to help to bring authorization into Elixir applications. W
 
 ## Documentation
 
-Master branch documentation can be found [here](https://patatoid.gitlab.io/boruta_auth/readme.html)
+Master branch documentation can be found [here](https://github.com/malach-it/boruta_auth/blob/master/README.md)
 
 Stable documentation is hosted on [hexdocs.pm](https://hexdocs.pm/boruta/api-reference.html)
 
 ## Integration example
 
-An example of integration can be found [here](https://gitlab.com/patatoid/boruta_example), it followed the integration steps described in below guides section.
+An example of integration can be found [here](https://github.com/patatoid/boruta_example), it followed the integration steps described in below guides section.
 
 ## OpenID Certification
 

--- a/guides/provider_integration.md
+++ b/guides/provider_integration.md
@@ -38,7 +38,7 @@ After that, you'll be able to generate controllers in order to expose Oauth and 
 ~> mix do deps.get, boruta.gen.migration, ecto.migrate, boruta.gen.controllers
 ```
 
-It will print the remaining steps to have the provider up and running as described in the [documentation](https://patatoid.gitlab.io/boruta_auth/Mix.Tasks.Boruta.Gen.Controllers.html). From there we will skip the testing part which uses Mox in order to mock Boruta and focus tests on the application layer.
+It will print the remaining steps to have the provider up and running as described in the [documentation](https://hexdocs.pm/boruta/Mix.Tasks.Boruta.Gen.Controllers.html). From there we will skip the testing part which uses Mox in order to mock Boruta and focus tests on the application layer.
 
 ## 3. Configure Boruta
 
@@ -80,7 +80,7 @@ Here client credentials flow should be up. For user flows you need further confi
 
 ## 4. User flows
 
-In order to have user flows operational, you need to implement `Boruta.Oauth.ResourceOwners` context as described in [Boruta README](https://patatoid.gitlab.io/boruta_auth/readme.html). Here it would look like
+In order to have user flows operational, you need to implement `Boruta.Oauth.ResourceOwners` context as described in [Boruta README](https://github.com/malach-it/boruta_auth/blob/master/README.md). Here it would look like
 ```elixir
 # lib/boruta_example/resource_owners.ex
 

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Boruta.MixProject do
       docs: docs(),
       package: package(),
       description: description(),
-      source_url: "https://gitlab.com/patatoid/boruta_auth",
+      source_url: "https://github.com/malach-it/boruta_auth",
       test_coverage: [
         ignore_modules: [
           Boruta.Repo,
@@ -71,7 +71,7 @@ defmodule Boruta.MixProject do
   defp docs do
     [
       main: "readme",
-      source_url: "https://gitlab.com/patatoid/boruta-core",
+      source_url: "https://github.com/malach-it/boruta_auth",
       source_ref: "master",
       extras: [
         "README.md",
@@ -178,7 +178,7 @@ defmodule Boruta.MixProject do
       name: "boruta",
       licenses: ["MIT"],
       links: %{
-        "Gitlab" => "https://gitlab.com/patatoid/boruta_auth"
+        "GitHub" => "https://github.com/malach-it/boruta_auth"
       }
     }
   end


### PR DESCRIPTION
Currently the links from hex.pm and hexdocs.pm are broken because they point to the now removed gitlab repos. This PR fixes that by updating all the links to equivalent GitHub or hexdocs links.