### PR TITLE
Add logo_uri and metadata to clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) according to OAuth / OpenID connect specifications, changes may break in order to comply with those.
 
+## [unreleased]
+
+- Note that you must run the `boruta.gen.migration` task to keep your database schema up to date while upgrading to this version.
+
+### Added
+
+- clients have a `metadata` attribute where one can store json objects
+- according to OpenID Connect core 1.0, clients have a `logo_uri` attribute
+
 ## [2.3.1] - 2023-04-24
 
 - Note that you must run the `boruta.gen.migration` task to keep your database schema up to date while upgrading to this version.

--- a/lib/boruta/adapters/ecto/schemas/client.ex
+++ b/lib/boruta/adapters/ecto/schemas/client.ex
@@ -94,6 +94,9 @@ defmodule Boruta.Ecto.Client do
 
     field(:userinfo_signed_response_alg, :string)
 
+    field(:logo_uri, :string)
+    field(:metadata, :map, default: %{})
+
     many_to_many :authorized_scopes, Scope,
       join_through: "oauth_clients_scopes",
       on_replace: :delete
@@ -126,7 +129,9 @@ defmodule Boruta.Ecto.Client do
       :public_revoke,
       :id_token_signature_alg,
       :id_token_kid,
-      :userinfo_signed_response_alg
+      :userinfo_signed_response_alg,
+      :logo_uri,
+      :metadata
     ])
     |> validate_required([:redirect_uris])
     |> unique_constraint(:id, name: :clients_pkey)
@@ -177,7 +182,9 @@ defmodule Boruta.Ecto.Client do
       :public_revoke,
       :id_token_signature_alg,
       :id_token_kid,
-      :userinfo_signed_response_alg
+      :userinfo_signed_response_alg,
+      :logo_uri,
+      :metadata
     ])
     |> validate_required([
       :authorization_code_ttl,

--- a/lib/boruta/oauth/schemas/client.ex
+++ b/lib/boruta/oauth/schemas/client.ex
@@ -35,7 +35,9 @@ defmodule Boruta.Oauth.Client do
             jwt_public_key: nil,
             jwks_uri: nil,
             public_key: nil,
-            private_key: nil
+            private_key: nil,
+            logo_uri: nil,
+            metadata: %{}
 
   @type t :: %__MODULE__{
           id: any(),
@@ -61,7 +63,9 @@ defmodule Boruta.Oauth.Client do
           jwt_public_key: String.t(),
           jwks_uri: String.t() | nil,
           public_key: String.t(),
-          private_key: String.t()
+          private_key: String.t(),
+          logo_uri: String.t() | nil,
+          metadata: map()
         }
 
   @grant_types [

--- a/priv/boruta/migrations/20230727181622_add_metadata_to_clients.ex
+++ b/priv/boruta/migrations/20230727181622_add_metadata_to_clients.ex
@@ -1,0 +1,16 @@
+defmodule Boruta.Migrations.AddMetadataToClients do
+  @moduledoc false
+
+  defmacro __using__(_args) do
+    quote do
+      def change do
+        # 20230727160245_add_metadata_to_clients.exs
+        alter table(:oauth_clients) do
+          add :metadata, :jsonb, default: "{}", null: false
+          add :logo_uri, :string
+        end
+      end
+    end
+  end
+end
+

--- a/priv/repo/migrations/20230727160245_add_metadata_to_clients.exs
+++ b/priv/repo/migrations/20230727160245_add_metadata_to_clients.exs
@@ -1,0 +1,10 @@
+defmodule Boruta.Repo.Migrations.AddMetadataToClients do
+  use Ecto.Migration
+
+  def change do
+    alter table(:oauth_clients) do
+      add :metadata, :jsonb, default: "{}", null: false
+      add :logo_uri, :string
+    end
+  end
+end

--- a/test/boruta/admin_test.exs
+++ b/test/boruta/admin_test.exs
@@ -159,6 +159,20 @@ defmodule Boruta.Ecto.AdminTest do
       assert id_token_ttl == 1
     end
 
+    test "creates a client with metadata" do
+      metadata = %{"metadata" => true}
+
+      assert {:ok,
+              %Client{
+                metadata: ^metadata
+              }} =
+               Admin.create_client(
+                 Map.merge(@client_valid_attrs, %{
+                   metadata: metadata
+                 })
+               )
+    end
+
     test "creates a client with authorized scopes by id" do
       scope = insert(:scope)
 
@@ -356,8 +370,7 @@ defmodule Boruta.Ecto.AdminTest do
       assert {:ok, %Client{public_key: ^public_key, private_key: ^private_key}} =
                Admin.regenerate_client_key_pair(client, public_key, private_key)
 
-      assert %Client{public_key: ^public_key, private_key: ^private_key} =
-               Repo.reload(client)
+      assert %Client{public_key: ^public_key, private_key: ^private_key} = Repo.reload(client)
     end
   end
 

--- a/test/boruta/openid/integration/dynamic_registration_test.exs
+++ b/test/boruta/openid/integration/dynamic_registration_test.exs
@@ -67,15 +67,20 @@ defmodule Boruta.OpenidTest.DynamicRegistrationTest do
       }
 
       redirect_uris = ["http://redirect.uri"]
+      logo_uri = "https://logo.uri"
 
       registration_params = %{
         redirect_uris: redirect_uris,
-        jwk: jwk
+        jwk: jwk,
+        logo_uri: logo_uri
       }
 
       assert {:client_registered,
-              %Oauth.Client{redirect_uris: ^redirect_uris, jwt_public_key: jwt_public_key}} =
-               Openid.register_client(:context, registration_params, ApplicationMock)
+              %Oauth.Client{
+                redirect_uris: ^redirect_uris,
+                jwt_public_key: jwt_public_key,
+                logo_uri: ^logo_uri
+              }} = Openid.register_client(:context, registration_params, ApplicationMock)
 
       assert JOSE.JWK.from_pem(jwt_public_key).kty == JOSE.JWK.from_map(jwk).kty
     end


### PR DESCRIPTION
Closes #11 

- Adds `metadata` attribute to clients where one can store arbitrary json data
- Adds `logo_uri` to clients according to OpenID Connect core 1.0