### PR TITLE
add redirect_uri_validation_fun config to allow validating non-standard URIs

### DIFF
--- a/lib/boruta/adapters/ecto/schemas/client.ex
+++ b/lib/boruta/adapters/ecto/schemas/client.ex
@@ -14,7 +14,8 @@ defmodule Boruta.Ecto.Client do
       access_token_max_ttl: 0,
       authorization_code_max_ttl: 0,
       id_token_max_ttl: 0,
-      refresh_token_max_ttl: 0
+      refresh_token_max_ttl: 0,
+      redirect_uri_validation_fun: 0
     ]
 
   alias Boruta.Ecto.Scope
@@ -291,10 +292,14 @@ defmodule Boruta.Ecto.Client do
     case URI.parse(uri) do
       %URI{scheme: scheme, host: host, fragment: fragment}
       when not is_nil(scheme) and not is_nil(host) and is_nil(fragment) ->
-        nil
+        # valid uri
+        nil 
 
       _ ->
-        "`#{uri}` is invalid"
+        case redirect_uri_validation_fun() do
+          {mod, fun} -> apply(mod, fun, [uri])
+          _ -> "`#{uri}` is invalid"
+        end
     end
   end
 

--- a/lib/boruta/config.ex
+++ b/lib/boruta/config.ex
@@ -135,12 +135,17 @@ defmodule Boruta.Config do
     Keyword.fetch!(oauth_config(), :issuer)
   end
 
+  @doc false
+  def redirect_uri_validation_fun do
+    Keyword.get(override_config(), :redirect_uri_validation_fun)
+  end
+
   @spec oauth_config() :: keyword()
   @doc false
   defp oauth_config do
       Keyword.merge(
         @defaults,
-        Application.get_env(:boruta, Boruta.Oauth) || [],
+        override_config() || [],
         fn _, a, b ->
           if Keyword.keyword?(a) && Keyword.keyword?(b) do
             Keyword.merge(a, b)
@@ -150,4 +155,7 @@ defmodule Boruta.Config do
         end
       )
   end
+
+  defp override_config, do: Application.get_env(:boruta, Boruta.Oauth)
+
 end


### PR DESCRIPTION
when authenticating mobile apps, the redirect_uri used is sometimes not a valid URI and was being rejected by the default validation function, so this allows extending it