### PR TITLE
chore: `List.zip/1` -> `Enum.zip/1`

### DIFF
--- a/lib/mix/tasks/boruta.gen.controllers.ex
+++ b/lib/mix/tasks/boruta.gen.controllers.ex
@@ -184,7 +184,7 @@ defmodule Mix.Tasks.Boruta.Gen.Controllers do
   end
 
   defp copy_modules(otp_app, assigns) do
-    List.zip([template_paths(@module_paths), @module_paths])
+    Enum.zip([template_paths(@module_paths), @module_paths])
     |> Enum.map(fn {source, controller_path} ->
       target =
         otp_app
@@ -196,7 +196,7 @@ defmodule Mix.Tasks.Boruta.Gen.Controllers do
   end
 
   defp copy_raw_files(otp_app, assigns) do
-    List.zip([raw_file_paths(@raw_file_paths), @raw_file_paths])
+    Enum.zip([raw_file_paths(@raw_file_paths), @raw_file_paths])
     |> Enum.map(fn {source, controller_path} ->
       target =
         otp_app
@@ -208,7 +208,7 @@ defmodule Mix.Tasks.Boruta.Gen.Controllers do
   end
 
   defp copy_test_files(otp_app, assigns) do
-    List.zip([template_paths(@test_files), @test_files])
+    Enum.zip([template_paths(@test_files), @test_files])
     |> Enum.map(fn {source, controller_path} ->
       target =
         otp_app


### PR DESCRIPTION
`List.zip/1` is deprecated in favor of `Enum.zip/1` 