### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "patatoid"
+    target-branch: "master"
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
I am not a big fan of Dependabot (I prefer renovate), but it seems fine to have it there. 