### PR TITLE
Use client from context instead of always using Ecto client

### DIFF
--- a/lib/boruta/adapters/ecto/oauth_mapper.ex
+++ b/lib/boruta/adapters/ecto/oauth_mapper.ex
@@ -6,7 +6,7 @@ defprotocol Boruta.Ecto.OauthMapper do
 end
 
 defimpl Boruta.Ecto.OauthMapper, for: Boruta.Ecto.Token do
-  import Boruta.Config, only: [repo: 0, resource_owners: 0]
+  import Boruta.Config, only: [repo: 0, resource_owners: 0, clients: 0]
 
   alias Boruta.Oauth
   alias Boruta.Oauth.ResourceOwner
@@ -17,7 +17,7 @@ defimpl Boruta.Ecto.OauthMapper, for: Boruta.Ecto.Token do
 
   def to_oauth_schema(%Ecto.Token{} = token) do
     client =
-      case Clients.get_client(token.client_id) do
+      case clients().get_client(token.client_id) do
         %Oauth.Client{} = client -> client
         _ -> nil
       end

--- a/lib/boruta/adapters/ecto/oauth_mapper.ex
+++ b/lib/boruta/adapters/ecto/oauth_mapper.ex
@@ -11,7 +11,6 @@ defimpl Boruta.Ecto.OauthMapper, for: Boruta.Ecto.Token do
   alias Boruta.Oauth
   alias Boruta.Oauth.ResourceOwner
   alias Boruta.Ecto
-  alias Boruta.Ecto.Clients
   alias Boruta.Ecto.AgentTokens
   alias Boruta.Ecto.OauthMapper
 


### PR DESCRIPTION
Hey! Thanks a lot for this amazing library 😌 

We want Boruta use our own client instead of storing in the database as we want to store the credentials to it in our secrets. To do that, we provide a custom client through the `contexts` configuration. However, the `Boruta.Ecto.OauthMapper`, which I believe we can't override, is always using the client via `Boruta.Ecto.Clients`. 

Instead, the `OauthMapper` can use the `clients` from the configuration `contexts`.