### PR TITLE
fix spec for AccessToken.authorize

### DIFF
--- a/lib/boruta/oauth/authorization/access_token.ex
+++ b/lib/boruta/oauth/authorization/access_token.ex
@@ -24,7 +24,7 @@ defmodule Boruta.Oauth.Authorization.AccessToken do
              :error_description => String.t(),
              :format => nil,
              :redirect_uri => nil,
-             :status => :unauthorized
+             :status => :bad_request
            }}
           | {:ok, %Token{}}
   def authorize(value: value) do


### PR DESCRIPTION
The status specified in the spec of `AccessToken.authorize/1`  doesn't match what is actually returned and is causing Dialyzer errors.

Though maybe what should be updated is the returned status. In that case, I will update the PR if you think that is the correct approach.