### PR TITLE
Use Erlang's md5, not crypto private key hashes

### DIFF
--- a/lib/boruta/oauth/schemas/client.ex
+++ b/lib/boruta/oauth/schemas/client.ex
@@ -294,7 +294,7 @@ defmodule Boruta.Oauth.Client do
 
     @spec kid_from_private_key(private_pem :: String.t()) :: kid :: String.t()
     def kid_from_private_key(private_pem) do
-      :crypto.hash(:md5, private_pem) |> Base.url_encode64() |> String.slice(0..16)
+      :erlang.md5(private_pem) |> Base.url_encode64() |> String.slice(0..16)
     end
 
     @spec userinfo_signature_type(Client.t()) :: userinfo_token_signature_type :: atom()


### PR DESCRIPTION
:crypto's md5 is disabled in a FIPS environment. Use the :erlang md5 instead.