### PR TITLE
Added form_post response mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - path wildcard (`**`) for redirect_uris
+- `form_post` response mode support per [OAuth 2.0 Form Post Response Mode](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html)
+- `response_mode` parameter support for code and token (implicit) flows
+- `FormPostResponse` struct with params helper for rendering HTML forms
+- `form_post_success/2` and `form_post_error/2` callbacks in `AuthorizeApplication` behaviour
 
 ## [3.0.0-beta.4] - 2025-07-05
 

--- a/lib/boruta/oauth/application.ex
+++ b/lib/boruta/oauth/application.ex
@@ -74,5 +74,27 @@ defmodule Boruta.Oauth.Application do
   @callback pushed_authorization_error(conn :: Plug.Conn.t(), oauth_error :: Boruta.Oauth.Error.t()) ::
               any()
 
-  @optional_callbacks preauthorize_success: 2, preauthorize_error: 2
+  @doc """
+  This function will be triggered when `response_mode=form_post` is requested and authorization succeeds.
+
+  The application layer is responsible for rendering an HTML page with a self-submitting form
+  that POSTs the authorization response parameters to the client's redirect_uri.
+
+  See `Boruta.Oauth.FormPostResponse` for details on the response structure and example HTML template.
+  """
+  @callback form_post_success(
+              conn :: Plug.Conn.t(),
+              form_post_response :: Boruta.Oauth.FormPostResponse.t()
+            ) :: any()
+
+  @doc """
+  This function will be triggered when `response_mode=form_post` is requested and authorization fails.
+
+  The application layer is responsible for rendering an HTML page with a self-submitting form
+  that POSTs the error parameters to the client's redirect_uri.
+  """
+  @callback form_post_error(conn :: Plug.Conn.t(), oauth_error :: Boruta.Oauth.Error.t()) ::
+              any()
+
+  @optional_callbacks preauthorize_success: 2, preauthorize_error: 2, form_post_success: 2, form_post_error: 2
 end

--- a/lib/boruta/oauth/applications/authorize_application.ex
+++ b/lib/boruta/oauth/applications/authorize_application.ex
@@ -34,5 +34,27 @@ defmodule Boruta.Oauth.AuthorizeApplication do
   @callback authorize_error(conn :: Plug.Conn.t(), oauth_error :: Boruta.Oauth.Error.t()) ::
               any()
 
-  @optional_callbacks preauthorize_success: 2, preauthorize_error: 2
+  @doc """
+  This function will be triggered when `response_mode=form_post` is requested and authorization succeeds.
+
+  The application layer is responsible for rendering an HTML page with a self-submitting form
+  that POSTs the authorization response parameters to the client's redirect_uri.
+
+  See `Boruta.Oauth.FormPostResponse` for details on the response structure and example HTML template.
+  """
+  @callback form_post_success(
+              conn :: Plug.Conn.t(),
+              form_post_response :: Boruta.Oauth.FormPostResponse.t()
+            ) :: any()
+
+  @doc """
+  This function will be triggered when `response_mode=form_post` is requested and authorization fails.
+
+  The application layer is responsible for rendering an HTML page with a self-submitting form
+  that POSTs the error parameters to the client's redirect_uri.
+  """
+  @callback form_post_error(conn :: Plug.Conn.t(), oauth_error :: Boruta.Oauth.Error.t()) ::
+              any()
+
+  @optional_callbacks preauthorize_success: 2, preauthorize_error: 2, form_post_success: 2, form_post_error: 2
 end

--- a/lib/boruta/oauth/json/schema.ex
+++ b/lib/boruta/oauth/json/schema.ex
@@ -158,7 +158,7 @@ defmodule Boruta.Oauth.Json.Schema do
       "type" => "object",
       "properties" => %{
         "response_type" => %{"type" => "string", "pattern" => "token"},
-        "response_mode" => %{"type" => "string", "pattern" => "^(query|fragment)$"},
+        "response_mode" => %{"type" => "string", "pattern" => "^(query|fragment|form_post)$"},
         "client_id" => %{
           "type" => "string",
           "pattern" => @uuid_pattern
@@ -178,7 +178,7 @@ defmodule Boruta.Oauth.Json.Schema do
       "type" => "object",
       "properties" => %{
         "response_type" => %{"type" => "string", "pattern" => "id_token"},
-        "response_mode" => %{"type" => "string", "pattern" => "^(query|fragment)$"},
+        "response_mode" => %{"type" => "string", "pattern" => "^(query|fragment|form_post)$"},
         "client_id" => %{
           "type" => "string"
         },
@@ -196,7 +196,7 @@ defmodule Boruta.Oauth.Json.Schema do
       "type" => "object",
       "properties" => %{
         "response_type" => %{"type" => "string", "pattern" => "vp_token"},
-        "response_mode" => %{"type" => "string", "pattern" => "^(query|fragment)$"},
+        "response_mode" => %{"type" => "string", "pattern" => "^(query|fragment|form_post)$"},
         "client_id" => %{"type" => "string"},
         "state" => %{"type" => "string"},
         "client_metadata" => %{"type" => "string"},
@@ -250,7 +250,7 @@ defmodule Boruta.Oauth.Json.Schema do
       "type" => "object",
       "properties" => %{
         "response_type" => %{"type" => "string", "pattern" => "code"},
-        "response_mode" => %{"type" => "string", "pattern" => "^(query|fragment)$"},
+        "response_mode" => %{"type" => "string", "pattern" => "^(query|fragment|form_post)$"},
         "client_id" => %{
           "type" => "string"
         },

--- a/lib/boruta/oauth/request/base.ex
+++ b/lib/boruta/oauth/request/base.ex
@@ -173,7 +173,8 @@ defmodule Boruta.Oauth.Request.Base do
       prompt: params["prompt"],
       code_challenge: params["code_challenge"],
       code_challenge_method: params["code_challenge_method"],
-      scope: params["scope"]
+      scope: params["scope"],
+      response_mode: params["response_mode"]
     }
 
     request =
@@ -230,6 +231,7 @@ defmodule Boruta.Oauth.Request.Base do
            redirect_uri: params["redirect_uri"],
            resource_owner: params["resource_owner"],
            response_types: response_types,
+           response_mode: params["response_mode"],
            scope: params["scope"],
            state: params["state"]
          }}

--- a/lib/boruta/oauth/requests/code_request.ex
+++ b/lib/boruta/oauth/requests/code_request.ex
@@ -20,6 +20,7 @@ defmodule Boruta.Oauth.CodeRequest do
           code_challenge: String.t(),
           code_challenge_method: String.t(),
           response_types: String.t(),
+          response_mode: String.t() | nil,
           authorization_details: String.t()
         }
 
@@ -36,6 +37,7 @@ defmodule Boruta.Oauth.CodeRequest do
             code_challenge: "",
             code_challenge_method: "plain",
             response_types: [],
+            response_mode: nil,
             authorization_details: "[]"
 
   alias Boruta.Oauth.Scope

--- a/lib/boruta/oauth/requests/token_request.ex
+++ b/lib/boruta/oauth/requests/token_request.ex
@@ -16,7 +16,8 @@ defmodule Boruta.Oauth.TokenRequest do
           scope: String.t(),
           resource_owner: struct(),
           grant_type: String.t(),
-          nonce: String.t()
+          nonce: String.t(),
+          response_mode: String.t() | nil
         }
   @enforce_keys [:client_id, :redirect_uri, :resource_owner]
   defstruct client_id: nil,
@@ -27,6 +28,7 @@ defmodule Boruta.Oauth.TokenRequest do
             grant_type: "implicit",
             nonce: nil,
             response_types: [],
+            response_mode: nil,
             prompt: ""
 
   alias Boruta.Oauth.Scope

--- a/lib/boruta/oauth/responses/authorize.ex
+++ b/lib/boruta/oauth/responses/authorize.ex
@@ -74,11 +74,7 @@ defmodule Boruta.Oauth.AuthorizeResponse do
         false -> :code
       end
 
-    response_mode =
-      case request.__struct__ do
-        HybridRequest -> request.response_mode
-        _ -> nil
-      end
+    response_mode = Map.get(request, :response_mode)
 
     %AuthorizeResponse{
       type: type,
@@ -104,7 +100,7 @@ defmodule Boruta.Oauth.AuthorizeResponse do
             state: state
           }
         } = params,
-        _request
+        request
       ) do
     {:ok, expires_at} = DateTime.from_unix(expires_at)
     expires_in = DateTime.diff(expires_at, DateTime.utc_now())
@@ -116,7 +112,8 @@ defmodule Boruta.Oauth.AuthorizeResponse do
       id_token: params[:id_token] && params[:id_token].value,
       expires_in: expires_in,
       state: state,
-      token_type: "bearer"
+      token_type: "bearer",
+      response_mode: Map.get(request, :response_mode)
     }
   end
 
@@ -128,13 +125,14 @@ defmodule Boruta.Oauth.AuthorizeResponse do
             state: state
           }
         },
-        _request
+        request
       ) do
     %AuthorizeResponse{
       type: :token,
       redirect_uri: redirect_uri,
       id_token: id_token,
-      state: state
+      state: state,
+      response_mode: Map.get(request, :response_mode)
     }
   end
 

--- a/lib/boruta/oauth/responses/form_post.ex
+++ b/lib/boruta/oauth/responses/form_post.ex
@@ -1,0 +1,105 @@
+defmodule Boruta.Oauth.FormPostResponse do
+  @moduledoc """
+  Response returned when `response_mode=form_post` is requested.
+
+  As defined in [OAuth 2.0 Form Post Response Mode](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html),
+  this response contains the authorization parameters that should be delivered to the client
+  via an HTML form that auto-submits via HTTP POST.
+
+  The application layer is responsible for rendering an HTML page with a self-submitting form.
+  The form should:
+  - Have `action` set to `redirect_uri`
+  - Have `method` set to "POST"
+  - Include each parameter as a hidden input field
+  - Auto-submit using JavaScript (e.g., `onload="document.forms[0].submit()"`)
+
+  ## Content Security Policy
+
+  When serving the form_post response, you should include a Content-Security-Policy header
+  with the `form-action` directive to restrict where the form can be submitted. This prevents
+  potential attackers from injecting forms that submit to malicious endpoints.
+
+  The `form-action` directive should be set to the client's `redirect_uri`:
+
+      Content-Security-Policy: form-action https://client.example.com/callback
+
+  ## Example Phoenix Controller
+
+  ```elixir
+  def form_post_success(conn, %FormPostResponse{} = response) do
+    conn
+    |> put_resp_header(
+      "content-security-policy",
+      "form-action \#{response.redirect_uri}"
+    )
+    |> put_resp_header("x-frame-options", "DENY")
+    |> put_resp_header("cache-control", "no-store")
+    |> put_resp_header("pragma", "no-cache")
+    |> put_view(MyAppWeb.OauthView)
+    |> render("form_post.html", response: response)
+  end
+  ```
+
+  ## Example HEEx Template (Phoenix 1.7+)
+
+  ```heex
+  <html>
+    <head><title>Submitting...</title></head>
+    <body onload="document.forms[0].submit()">
+      <form method="POST" action={@response.redirect_uri}>
+        <input
+          :for={{name, value} <- FormPostResponse.params(@response)}
+          type="hidden"
+          name={name}
+          value={value}
+        />
+        <noscript>
+          <p>JavaScript is disabled. Click the button below to continue.</p>
+          <input type="submit" value="Continue" />
+        </noscript>
+      </form>
+    </body>
+  </html>
+  ```
+  """
+
+  @enforce_keys [:redirect_uri]
+  defstruct redirect_uri: nil,
+            access_token: nil,
+            code: nil,
+            expires_in: nil,
+            id_token: nil,
+            state: nil,
+            token_type: nil,
+            type: nil
+
+  @type t :: %__MODULE__{
+          redirect_uri: String.t(),
+          access_token: String.t() | nil,
+          code: String.t() | nil,
+          expires_in: integer() | nil,
+          id_token: String.t() | nil,
+          state: String.t() | nil,
+          token_type: String.t() | nil,
+          type: :token | :code | :hybrid
+        }
+
+  @doc """
+  Returns the response parameters as a map suitable for form fields.
+
+  Only includes non-nil values.
+  """
+  @spec params(t()) :: %{atom() => String.t() | integer()}
+  def params(%__MODULE__{} = response) do
+    %{
+      code: response.code,
+      id_token: response.id_token,
+      access_token: response.access_token,
+      expires_in: response.expires_in,
+      state: response.state,
+      token_type: response.token_type
+    }
+    |> Enum.filter(fn {_key, value} -> not is_nil(value) end)
+    |> Enum.into(%{})
+  end
+end

--- a/test/boruta/oauth/error_test.exs
+++ b/test/boruta/oauth/error_test.exs
@@ -1,7 +1,11 @@
 defmodule Boruta.Oauth.ErrorTest do
   use ExUnit.Case
 
+  alias Boruta.Oauth.CodeRequest
   alias Boruta.Oauth.Error
+  alias Boruta.Oauth.HybridRequest
+  alias Boruta.Oauth.ResourceOwner
+  alias Boruta.Oauth.TokenRequest
 
   describe "with_format/2" do
     test "returns error with nil format when client is invalid" do
@@ -14,6 +18,97 @@ defmodule Boruta.Oauth.ErrorTest do
                  },
                  %{}
                )
+    end
+
+    test "returns error with form_post format for code request with response_mode=form_post" do
+      request = %CodeRequest{
+        client_id: "client_id",
+        redirect_uri: "http://redirect.uri",
+        resource_owner: %ResourceOwner{sub: "sub"},
+        state: "state",
+        response_mode: "form_post"
+      }
+
+      error = %Error{
+        status: :bad_request,
+        error: :invalid_scope,
+        error_description: "error_description"
+      }
+
+      assert %Error{format: :form_post, redirect_uri: "http://redirect.uri", state: "state"} =
+               Error.with_format(error, request)
+    end
+
+    test "returns error with form_post format for token request with response_mode=form_post" do
+      request = %TokenRequest{
+        client_id: "client_id",
+        redirect_uri: "http://redirect.uri",
+        resource_owner: %ResourceOwner{sub: "sub"},
+        state: "state",
+        response_mode: "form_post"
+      }
+
+      error = %Error{
+        status: :bad_request,
+        error: :invalid_scope,
+        error_description: "error_description"
+      }
+
+      assert %Error{format: :form_post, redirect_uri: "http://redirect.uri", state: "state"} =
+               Error.with_format(error, request)
+    end
+
+    test "returns error with form_post format for hybrid request with response_mode=form_post" do
+      request = %HybridRequest{
+        client_id: "client_id",
+        redirect_uri: "http://redirect.uri",
+        resource_owner: %ResourceOwner{sub: "sub"},
+        state: "state",
+        response_mode: "form_post"
+      }
+
+      error = %Error{
+        status: :bad_request,
+        error: :invalid_scope,
+        error_description: "error_description"
+      }
+
+      assert %Error{format: :form_post, redirect_uri: "http://redirect.uri", state: "state"} =
+               Error.with_format(error, request)
+    end
+
+    test "returns error with query format for code request without response_mode" do
+      request = %CodeRequest{
+        client_id: "client_id",
+        redirect_uri: "http://redirect.uri",
+        resource_owner: %ResourceOwner{sub: "sub"},
+        state: "state"
+      }
+
+      error = %Error{
+        status: :bad_request,
+        error: :invalid_scope,
+        error_description: "error_description"
+      }
+
+      assert %Error{format: :query} = Error.with_format(error, request)
+    end
+
+    test "returns error with fragment format for token request without response_mode" do
+      request = %TokenRequest{
+        client_id: "client_id",
+        redirect_uri: "http://redirect.uri",
+        resource_owner: %ResourceOwner{sub: "sub"},
+        state: "state"
+      }
+
+      error = %Error{
+        status: :bad_request,
+        error: :invalid_scope,
+        error_description: "error_description"
+      }
+
+      assert %Error{format: :fragment} = Error.with_format(error, request)
     end
   end
 

--- a/test/boruta/oauth/responses/authorize_test.exs
+++ b/test/boruta/oauth/responses/authorize_test.exs
@@ -118,5 +118,31 @@ defmodule Boruta.Oauth.AuthorizeResponseTest do
       assert AuthorizeResponse.redirect_to_url(response) ==
                "http://redirect.uri?code=value&state=state&foo=bar"
     end
+
+    test "returns query params according to `response_mode` for code requests" do
+      response = %AuthorizeResponse{
+        type: :code,
+        code: "value",
+        state: "state",
+        redirect_uri: "http://redirect.uri",
+        response_mode: "query"
+      }
+
+      assert AuthorizeResponse.redirect_to_url(response) ==
+               "http://redirect.uri?code=value&state=state"
+    end
+
+    test "returns fragment according to `response_mode` for token requests" do
+      response = %AuthorizeResponse{
+        type: :token,
+        access_token: "value",
+        expires_in: 10,
+        redirect_uri: "http://redirect.uri",
+        response_mode: "fragment"
+      }
+
+      assert AuthorizeResponse.redirect_to_url(response) ==
+               "http://redirect.uri#access_token=value&expires_in=10"
+    end
   end
 end

--- a/test/boruta/oauth/responses/form_post_response_test.exs
+++ b/test/boruta/oauth/responses/form_post_response_test.exs
@@ -1,0 +1,92 @@
+defmodule Boruta.Oauth.FormPostResponseTest do
+  use ExUnit.Case
+
+  alias Boruta.Oauth.FormPostResponse
+
+  describe "params/1" do
+    test "returns params map with code" do
+      response = %FormPostResponse{
+        redirect_uri: "http://redirect.uri",
+        code: "authorization_code",
+        state: "state_value",
+        type: :code
+      }
+
+      assert FormPostResponse.params(response) == %{
+               code: "authorization_code",
+               state: "state_value"
+             }
+    end
+
+    test "returns params map with access_token" do
+      response = %FormPostResponse{
+        redirect_uri: "http://redirect.uri",
+        access_token: "access_token_value",
+        token_type: "bearer",
+        expires_in: 3600,
+        state: "state_value",
+        type: :token
+      }
+
+      assert FormPostResponse.params(response) == %{
+               access_token: "access_token_value",
+               token_type: "bearer",
+               expires_in: 3600,
+               state: "state_value"
+             }
+    end
+
+    test "returns params map with id_token" do
+      response = %FormPostResponse{
+        redirect_uri: "http://redirect.uri",
+        id_token: "id_token_value",
+        state: "state_value",
+        type: :token
+      }
+
+      assert FormPostResponse.params(response) == %{
+               id_token: "id_token_value",
+               state: "state_value"
+             }
+    end
+
+    test "returns params map with hybrid response" do
+      response = %FormPostResponse{
+        redirect_uri: "http://redirect.uri",
+        code: "authorization_code",
+        access_token: "access_token_value",
+        id_token: "id_token_value",
+        token_type: "bearer",
+        expires_in: 3600,
+        state: "state_value",
+        type: :hybrid
+      }
+
+      assert FormPostResponse.params(response) == %{
+               code: "authorization_code",
+               access_token: "access_token_value",
+               id_token: "id_token_value",
+               token_type: "bearer",
+               expires_in: 3600,
+               state: "state_value"
+             }
+    end
+
+    test "excludes nil values from params" do
+      response = %FormPostResponse{
+        redirect_uri: "http://redirect.uri",
+        code: "authorization_code",
+        access_token: nil,
+        id_token: nil,
+        token_type: nil,
+        expires_in: nil,
+        state: nil,
+        type: :code
+      }
+
+      assert FormPostResponse.params(response) == %{
+               code: "authorization_code"
+             }
+    end
+  end
+end


### PR DESCRIPTION
Add `form_post` response mode support

Implement OAuth 2.0 Form Post Response Mode per the OpenID specification.  This delivers authorization responses via an auto-submitting HTML form that POSTs to the client's `redirect_uri`.

Changes:
- Add form_post to response_mode validation (query|fragment|form_post)
- Extend response_mode support to code and token flows (was hybrid only)
- Create FormPostResponse struct with params/1 helper
- Add `form_post_success/2` and `form_post_error/2` behaviour callbacks
- Route errors to form_post_error when response_mode is form_post
- Document CSP form-action directive and security headers

Spec: https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html

Closes https://github.com/malach-it/boruta_auth/issues/10