### PR TITLE
Fix RS384/HS384 typo in JWT client auth algorithm guard

### DIFF
--- a/lib/boruta/oauth/authorization/client.ex
+++ b/lib/boruta/oauth/authorization/client.ex
@@ -314,7 +314,7 @@ defmodule Boruta.Oauth.Authorization.Client do
          } = client,
          _message
        )
-       when alg in ["HS256", "HS364", "HS512"] and is_binary(secret) do
+       when alg in ["HS256", "HS384", "HS512"] and is_binary(secret) do
     signer = Joken.Signer.create(alg, secret)
 
     case {source[:type], Token.verify(source[:value] || "", signer)} do
@@ -341,7 +341,7 @@ defmodule Boruta.Oauth.Authorization.Client do
          } = client,
          _message
        )
-       when alg in ["RS256", "RS364", "RS512"] and is_binary(jwt_public_key) do
+       when alg in ["RS256", "RS384", "RS512"] and is_binary(jwt_public_key) do
     signer = Joken.Signer.create(alg, %{"pem" => jwt_public_key})
     verify = Token.verify(source[:value] || "", signer)
 

--- a/test/boruta/oauth/authorization/client_test.exs
+++ b/test/boruta/oauth/authorization/client_test.exs
@@ -162,6 +162,21 @@ defmodule Boruta.Oauth.Authorization.ClientTest do
                Client.authorize(id: client.id, source: source, grant_type: "client_credentials")
     end
 
+    test "authorizes with client secret jwt auth method (HS384)" do
+      client =
+        insert(:client,
+          token_endpoint_auth_methods: ["client_secret_jwt"],
+          token_endpoint_jwt_auth_alg: "HS384"
+        )
+
+      signer = Joken.Signer.create("HS384", client.secret)
+      {:ok, client_assertion, _claims} = Token.encode_and_sign(%{}, signer)
+      source = %{type: "jwt", value: client_assertion}
+
+      assert {:ok, _client} =
+               Client.authorize(id: client.id, source: source, grant_type: "client_credentials")
+    end
+
     test "returns an error with nil client secret jwt auth method" do
       client =
         insert(:client,
@@ -207,6 +222,22 @@ defmodule Boruta.Oauth.Authorization.ClientTest do
         )
 
       signer = Joken.Signer.create("RS512", %{"pem" => valid_private_key()})
+      {:ok, client_assertion, _claims} = Token.encode_and_sign(%{}, signer)
+      source = %{type: "jwt", value: client_assertion}
+
+      assert {:ok, _client} =
+               Client.authorize(id: client.id, source: source, grant_type: "client_credentials")
+    end
+
+    test "authorizes with private key jwt auth method (RS384)" do
+      client =
+        insert(:client,
+          token_endpoint_auth_methods: ["private_key_jwt"],
+          token_endpoint_jwt_auth_alg: "RS384",
+          jwt_public_key: valid_public_key()
+        )
+
+      signer = Joken.Signer.create("RS384", %{"pem" => valid_private_key()})
       {:ok, client_assertion, _claims} = Token.encode_and_sign(%{}, signer)
       source = %{type: "jwt", value: client_assertion}
 


### PR DESCRIPTION
## Summary

`client_secret_jwt` and `private_key_jwt` client authentication verify `token_endpoint_jwt_auth_alg` against a hardcoded algorithm list in `Boruta.Oauth.Authorization.Client`:

```elixir
when alg in ["HS256", "HS364", "HS512"] and is_binary(secret) do          # client_secret_jwt
when alg in ["RS256", "RS364", "RS512"] and is_binary(jwt_public_key) do  # private_key_jwt
```

`HS364`/`RS364` aren't real JOSE algorithm identifiers — they should be `HS384`/`RS384`. The Ecto client schema's own algorithm allowlist (`@token_endpoint_jwt_auth_algs`) is spelled correctly and happily lets a client be created/updated with `token_endpoint_jwt_auth_alg: "RS384"` (or `"HS384"`), but that client can then never successfully authenticate, since the verification guard clause will never match. It's a silent configuration trap: nothing errors until an admin/relying party tries to actually use the client.

## Changes

- Fix the two typo'd algorithm lists in `lib/boruta/oauth/authorization/client.ex`.
- Add regression tests for `client_secret_jwt`/`private_key_jwt` with
  HS384/RS384, mirroring the existing HS512/RS512 coverage. Verified these
  fail against the old code and pass with the fix.

## Test plan

- [x] `mix test` — full suite passing
- [x] New tests confirmed to fail against the pre-fix code (temporarily reverted the fix, reran, both failed with "Bad client jwt authentication method configuration"; restored fix, both pass)
- [x] `mix credo --strict` clean on changed files