### PR TITLE
start `Boruta.Cache` only when it is the configured `cache_backend`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) according to OAuth / OpenID connect specifications, changes may break in order to comply with those.
 
+## [Unreleased]
+
+### Fixed
+
+- `Boruta.Cache` is started only when it is the configured `cache_backend`
+
 ## [2.3.8] - 2026-08-01
 
 ### Fixed

--- a/lib/boruta/application.ex
+++ b/lib/boruta/application.ex
@@ -6,11 +6,15 @@ defmodule Boruta.Application do
   use Application
 
   def start(_type, _args) do
-    children = [
-      Boruta.Cache,
-      {Finch, name: OpenIDHttpClient}
-    ]
+    children = cache_children() ++ [{Finch, name: OpenIDHttpClient}]
 
     Supervisor.start_link(children, strategy: :one_for_one, name: Boruta.Supervisor)
+  end
+
+  defp cache_children do
+    case Boruta.Config.cache_backend() do
+      Boruta.Cache -> [Boruta.Cache]
+      _other_backend -> []
+    end
   end
 end

--- a/lib/boruta/config.ex
+++ b/lib/boruta/config.ex
@@ -23,6 +23,8 @@ defmodule Boruta.Config do
     token_generator: Boruta.TokenGenerator,
     issuer: "boruta"
   ```
+
+  `Boruta.Cache` is started with the application only when it is the configured `cache_backend`; another backend is started by the host application.
   """
 
   @defaults cache_backend: Boruta.Cache,

--- a/test/boruta/application_test.exs
+++ b/test/boruta/application_test.exs
@@ -1,0 +1,33 @@
+defmodule Boruta.ApplicationTest do
+  use ExUnit.Case, async: false
+
+  defmodule OtherCache do
+    def get(_key), do: {:ok, nil}
+    def put(_key, _value, _opts \\ []), do: :ok
+    def delete(_key), do: :ok
+  end
+
+  test "starts Boruta.Cache when it is the configured cache backend" do
+    assert is_pid(Process.whereis(Boruta.Cache))
+  end
+
+  test "does not start Boruta.Cache when another cache backend is configured" do
+    config = Application.get_env(:boruta, Boruta.Oauth)
+
+    on_exit(fn ->
+      Application.put_env(:boruta, Boruta.Oauth, config)
+      restart_boruta()
+    end)
+
+    Application.put_env(:boruta, Boruta.Oauth, Keyword.put(config, :cache_backend, OtherCache))
+    restart_boruta()
+
+    assert is_pid(Process.whereis(Boruta.Supervisor))
+    assert Process.whereis(Boruta.Cache) == nil
+  end
+
+  defp restart_boruta do
+    :ok = Application.stop(:boruta)
+    {:ok, _apps} = Application.ensure_all_started(:boruta)
+  end
+end


### PR DESCRIPTION
Fixes #80.

- `Boruta.Application`: `Boruta.Cache` joins the children only when `Boruta.Config.cache_backend()` is `Boruta.Cache`. A host that configures another backend starts that backend itself, as before; the default configuration is unchanged.
- `Boruta.Config`: one sentence in the moduledoc stating when `Boruta.Cache` is started.
- `test/boruta/application_test.exs`: with the default configuration `Boruta.Cache` is running; with another `cache_backend` the application restarts without it (the test restores the configuration and restarts the application on exit).
- CHANGELOG.

Verified on Postgres 17: full test suite green, `mix format` and `mix credo --strict` clean on the touched files.
